### PR TITLE
bug: user update by multifields, param need '...'

### DIFF
--- a/src/models/user.go
+++ b/src/models/user.go
@@ -95,7 +95,7 @@ func (u *User) Update(selectField interface{}, selectFields ...interface{}) erro
 		return err
 	}
 
-	return DB().Model(u).Select(selectField, selectFields).Updates(u).Error
+	return DB().Model(u).Select(selectField, selectFields...).Updates(u).Error
 }
 
 func (u *User) UpdateAllFields() error {


### PR DESCRIPTION
**bug**

**多字段更新用户时，参数作为slice接受，需要拆包之后再往下传入。  
该bug导致user.Update方法只能成功更新第一个参数对应的字段**:
<!--
"Nice to have" "You need it" is not a good reason. :)
-->

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or "Fixes (paste link of issue)"
-->
无
 
**Special notes for your reviewer**:
无